### PR TITLE
Improve UX of the consent popup

### DIFF
--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -107,7 +107,7 @@ export default class ConsentNotice extends React.Component {
 							type="button"
 							onClick={saveAndHide}
 						>
-							{t(['ok'])}
+							{t(['apply'])}
 						</button>
 					</div>
 				</div>

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -103,13 +103,6 @@ export default class ConsentNotice extends React.Component {
 					</div>
 					<div className="cn-ok">
 						<button
-							className="btn btn-default"
-							type="button"
-							onClick={declineAndHide}
-						>
-							{t(['decline'])}
-						</button>
-						<button
 							className="btn btn-success"
 							type="button"
 							onClick={saveAndHide}

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -87,15 +87,20 @@ export default class ConsentNotice extends React.Component {
 						})}
 					</p>
 					{changesText}
-					<Apps
-						t={t}
-						config={config}
-						manager={manager}
-						text={false}
-					/>
+					<div className="cn-apps">
+						<span className="nc-choose">
+							{t(['consentNotice', 'chooseTitle'])}
+						</span>
+						<Apps
+							t={t}
+							config={config}
+							manager={manager}
+							text={false}
+						/>
 						<a href="#" onClick={showModal}>
 							{t(['consentNotice', 'settings'])}
 						</a>
+					</div>
 					<div className="cn-ok">
 						<button
 							className="btn btn-default"

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -85,9 +85,6 @@ export default class ConsentNotice extends React.Component {
 						{t(['consentNotice', 'description'], {
 							purposes: <strong>{purposesText}</strong>
 						})}
-						<a href="#" onClick={showModal}>
-							{t(['consentNotice', 'settings'])}...
-						</a>
 					</p>
 					{changesText}
 					<Apps
@@ -96,6 +93,9 @@ export default class ConsentNotice extends React.Component {
 						manager={manager}
 						text={false}
 					/>
+						<a href="#" onClick={showModal}>
+							{t(['consentNotice', 'settings'])}
+						</a>
 					<div className="cn-ok">
 						<button
 							className="btn btn-default"

--- a/src/scss/klaro.scss
+++ b/src/scss/klaro.scss
@@ -180,19 +180,23 @@ $socs-green: #27b646;
 				ul.cm-apps {
 					padding: 0;
 					margin: 0;
+
 					li.cm-app {
 						&:first-child {
 							margin-top: 0;
 						}
+
 						position: relative;
 						line-height: 20px;
 						vertical-align: middle;
 						padding-left: 60px;
 						min-height: 40px;
+
 						.switch {
 							position: absolute;
 							left: 0;
 						}
+
 						p {
 							margin-top: 0;
 						}
@@ -235,6 +239,10 @@ $socs-green: #27b646;
 
 		input {
 			margin-right: 5px;
+		}
+
+		li {
+			margin-top: 0;
 		}
 
 		@media (min-width: 990px) {
@@ -296,6 +304,18 @@ $socs-green: #27b646;
 			}
 
 			a.cn-decline {
+			}
+
+			.cn-apps {
+				.nc-choose {
+					font-weight: bold;
+					color: $font-color-dark;
+				}
+
+				ul.cm-apps {
+					margin-top: 0;
+					margin-bottom: 0.5rem;
+				}
 			}
 		}
 	}

--- a/src/translations/en.yml
+++ b/src/translations/en.yml
@@ -17,6 +17,7 @@ consentNotice:
 ok: OK
 save: Save
 decline: Decline
+apply: Apply
 close: Close
 app:
     disableAll:

--- a/src/translations/en.yml
+++ b/src/translations/en.yml
@@ -9,6 +9,7 @@ consentModal:
 consentNotice:
     title: This website uses cookies.
     changeDescription: There were changes since your last visit, please update your consent.
+    chooseTitle: Choose which cookies you want to accept
     description: >
         To give you the best possible experience this site uses cookies.
     learnMore: Learn more

--- a/src/translations/nl.yml
+++ b/src/translations/nl.yml
@@ -9,10 +9,11 @@ consentModal:
 consentNotice:
     title: Deze website gebruikt cookies.
     changeDescription: Er waren wijzigingen sinds uw laatste bezoek, werk uw voorkeuren bij.
+    chooseTitle: Kies welke cookies u wilt accepteren
     description: >
         Om u een prettige ervaring op onze website te bieden maakt onze website gebruik van cookies.
     learnMore: Lees meer
-    settings: instellingen
+    settings: Meer informatie
 ok: OK
 save: Opslaan
 decline: Afwijzen

--- a/src/translations/nl.yml
+++ b/src/translations/nl.yml
@@ -16,6 +16,7 @@ consentNotice:
     settings: Meer informatie
 ok: OK
 save: Opslaan
+apply: Toepassen
 decline: Afwijzen
 close: Sluiten
 app:


### PR DESCRIPTION
This adds some UX improvements to the popup window:

- [x] add a title to instruct the user what to do
- [x] move the settings link beneath the options and change the text to more info
- [x] remove the reject button because it's now clear that there will be no cookies accepted before the user clicked apply